### PR TITLE
return anything from with_connection

### DIFF
--- a/src/based.gleam
+++ b/src/based.gleam
@@ -18,8 +18,8 @@ pub type Query(a) {
 }
 
 /// Defines a valid `with_connection` function
-pub type WithConnection(a, b, c) =
-  fn(b, fn(DB(a, c)) -> Result(Returned(a), Nil)) -> Result(Returned(a), Nil)
+pub type WithConnection(a, b, c, t) =
+  fn(b, fn(DB(a, c)) -> t) -> t
 
 pub type Returned(a) {
   Returned(count: Int, rows: List(a))
@@ -38,10 +38,10 @@ pub type DB(a, c) {
 /// In the case of `based/testing.with_connection`, the required argument is the expected
 /// return data.
 pub fn register(
-  with_connection: WithConnection(a, b, c),
+  with_connection: WithConnection(a, b, c, t),
   b: b,
-  callback: fn(DB(a, c)) -> Result(Returned(a), Nil),
-) -> Result(Returned(a), Nil) {
+  callback: fn(DB(a, c)) -> t,
+) -> t {
   with_connection(b, callback)
 }
 

--- a/src/based/testing.gleam
+++ b/src/based/testing.gleam
@@ -1,21 +1,16 @@
-import based.{type Adapter, type DB, type Returned, DB, Returned}
+import based.{type DB, type Returned, DB, Returned}
 
 /// A mock connection
 pub type Connection {
   Connection(c: Nil)
 }
 
-/// A mock database adapter
-pub fn adapter(returned: Result(Returned(a), Nil)) -> Adapter(a, c) {
-  fn(_query, _connection) { returned }
-}
-
 /// For testing code without hitting a real database
 pub fn with_connection(
   returned: Result(Returned(a), Nil),
-  callback: fn(DB(a, Connection)) -> Result(o, e),
-) -> Result(o, e) {
+  callback: fn(DB(a, Connection)) -> t,
+) -> t {
   Connection(Nil)
-  |> DB(adapter(returned))
+  |> DB(fn(_, _) { returned })
   |> callback
 }

--- a/test/based_test.gleam
+++ b/test/based_test.gleam
@@ -23,10 +23,14 @@ pub fn exec_test() {
 
     use db <- based.register(testing.with_connection, returned)
 
-    query |> based.exec(db)
+    query
+    |> based.exec(db)
+    |> should.be_ok
+
+    Nil
   }
 
-  result |> should.be_ok
+  result |> should.equal(Nil)
 }
 
 pub fn exec_without_return_test() {
@@ -36,12 +40,16 @@ pub fn exec_without_return_test() {
   let result = {
     let returning = Ok(Returned(0, []))
 
-    use db <- testing.with_connection(returning)
+    use db <- based.register(testing.with_connection, returning)
 
-    query |> based.exec(db)
+    query
+    |> based.exec(db)
+    |> should.be_ok
+
+    Nil
   }
 
-  result |> should.be_ok
+  result |> should.equal(Nil)
 }
 
 pub fn new_query_test() {


### PR DESCRIPTION
`with_connection` can only return a `Result(Returned(a), Nil)` type which limits the usefulness of this function and ultimately of the whole package.

This PR allows a `with_connection` function to return anything. 