### PR TITLE
deprecate transaction function and TxHandler type

### DIFF
--- a/src/based.gleam
+++ b/src/based.gleam
@@ -145,6 +145,7 @@ pub type Returning(a) {
 /// A function provided by an adapter package that wraps a callback in a
 /// database transaction. The handler receives a connection and a callback;
 /// it is responsible for committing on `Ok` and rolling back on `Error`.
+@deprecated("Use the transaction function provided by an adapter package.")
 pub type TxHandler(conn, t, error) =
   fn(conn, fn(conn) -> Result(t, error)) -> Result(t, TransactionError(error))
 
@@ -152,6 +153,7 @@ pub type TxHandler(conn, t, error) =
 ///
 /// The handler (supplied by an adapter package) is responsible for beginning
 /// the transaction, committing on success, and rolling back on failure.
+@deprecated("Use the transaction function provided by an adapter package.")
 pub fn transaction(
   db: Db(v, conn),
   handler: TxHandler(conn, t, error),


### PR DESCRIPTION
The `based.transaction` function does not serve a useful purpose. Users still need to provide the transaction function from their chosen adapter package, so they might as well use that function directly.